### PR TITLE
Add wfe as an alternative to wfi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["asynchronous", "embedded", "no-std"]
 
 [features]
 cortex_m = ["cortex-m"]
+wfe = ["cortex-m"]
 
 [dependencies]
 bare-metal = "0.2"

--- a/src/task.rs
+++ b/src/task.rs
@@ -191,17 +191,15 @@ impl Runtime {
     }
 
     unsafe fn run_once(&self) {
-        interrupt::free(|cs| {
-            if self
-                .tasks
+        if interrupt::free(|cs| {
+            self.tasks
                 .with_first(cs, |first| first.run_once(cs))
                 .is_none()
-            {
-                #[cfg(all(feature = "cortex_m", not(feature = "wfe")))]
-                cortex_m::asm::wfi();
-                #[cfg(all(feature = "cortex_m", feature = "wfe"))]
-                cortex_m::asm::wfe();
-            }
-        });
+        }) {
+            #[cfg(all(feature = "cortex_m", not(feature = "wfe")))]
+            cortex_m::asm::wfi();
+            #[cfg(all(feature = "cortex_m", feature = "wfe"))]
+            cortex_m::asm::wfe();
+        };
     }
 }

--- a/src/task.rs
+++ b/src/task.rs
@@ -197,10 +197,10 @@ impl Runtime {
                 .with_first(cs, |first| first.run_once(cs))
                 .is_none()
             {
-                #[cfg(feature = "cortex_m")]
-                {
-                    cortex_m::asm::wfi();
-                }
+                #[cfg(all(feature = "cortex_m", not(feature = "wfe")))]
+                cortex_m::asm::wfi();
+                #[cfg(all(feature = "cortex_m", feature = "wfe"))]
+                cortex_m::asm::wfe();
             }
         });
     }


### PR DESCRIPTION
One multicore system (such as the rp2040) one core can wake the other core by generating an event using the `sev` instruction. This does not trigger and interrupt and therefore does not wake from wfi.